### PR TITLE
Idle time fixes

### DIFF
--- a/changes/changes.4.3.2.tcz
+++ b/changes/changes.4.3.2.tcz
@@ -1,0 +1,15 @@
+The Chatting Zone (TCZ)  -  Changes log for TCZ v4.3.2
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+ Date:       Name, Source, Func/Procedure & Description of change:
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+ dd/mm/yyyy  TODO: many commits to add
+ 08/06/2020  (N.Anderson:  interface.c) Fixed bug where idle time tracking
+             was circumvented by QUIT/disconnection
+ 09/06/2020  (N.Anderson:  interface.c, server.c) Fixed bug in how idletime 
+             was tracked.  Time spent idle in AFK prompt is now tracked
+             as idle
+-------------------------------------------------------------------------------
+ KEY:  '**' = Document to users (I.e:  On BBS.)
+       '##' = Document to Admin only.
+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-

--- a/src/interface.c
+++ b/src/interface.c
@@ -699,6 +699,12 @@ void tcz_command(struct descriptor_data *d,dbref player,const char *command)
            writelog(MONITOR_LOG,1,"MONITOR","(%s(#%d) (%s) in %s)  >>>>>  %s",getname(player),player,IsHtml(d) ? "HTML":"Telnet",unparse_object(ROOT,Location(player),0),ptr);
 	}
 
+     /* ---->  Track idle time  <---- */
+     if(d->flags & CONNECTED)
+        if(((now - d->last_time) >= (IDLE_TIME * MINUTE)) && Validchar(d->player))
+           db[d->player].data->player.idletime += (now - d->last_time); 
+     d->last_time = now;
+
      /* ---->  Update hourly payment counter and zero idle time of user  <---- */
      finance_payment(d);
 

--- a/src/server.c
+++ b/src/server.c
@@ -2714,11 +2714,7 @@ int server_command(struct descriptor_data *d,char *command)
        }
     } else if(!(d->flags & CONNECTED)) {
 
-       if(((now - d->last_time) >= (IDLE_TIME * MINUTE)) && Validchar(d->player))
-          db[d->player].data->player.idletime += (now - d->last_time);
-
        d->warning_level = 0;
-       d->last_time     = now;
        
        if(!strcasecmp(command,"WHO") || !strncasecmp(command,"WHO ",4)) {
           while(*command && (*command != ' ')) command++;
@@ -2796,7 +2792,6 @@ int server_command(struct descriptor_data *d,char *command)
        } else if(!server_connect_user(d,command)) return(0);
        } else if(!compoundonly && (d->clevel > 0)) {
        d->warning_level = 0;
-       d->last_time     = now;
        if(!server_connect_user(d,command)) return(0);
     } else server_current_last(d,command);
 


### PR DESCRIPTION
Time spent in the AFK prompt now works properly with 5 minute idle threshold in it's impact to @?totalactive