### PR TITLE
Fixed a bug where characters that idled out the full 60 minutes were …

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1282,8 +1282,6 @@ void server_mainloop(void)
 
                         /* ---->  Maximum allowed idle time of connected user exceeded (MAX_IDLE_TIME minutes)  <---- */
                         sprintf(bootmessage,"\n"ANSI_WRED"\x07[You have been idle for "ANSI_WWHITE"%d minute%s"ANSI_WRED"  -  You have been automatically disconnected from %s...]\n",MAX_IDLE_TIME,Plural(MAX_IDLE_TIME),tcz_full_name);
-			/* Stop people getting 60 full active minutes */
-			db[d->player].data->player.idletime += ((MAX_IDLE_TIME - 5) * 60);
                         server_shutdown_sock(d,0,0);                        
 		     } else if(diff > ((WARN_IDLE_TIME + (d->warning_level * 5)) * MINUTE)) {
 


### PR DESCRIPTION
…penalized twice on their idletime.

Here is some output that shows 2 characters (Newguy and Newgal) idling and the spod board shortly before and after
they disconnect.  Root was nearly 8 minutes idle, so we expect no change in "totalactive" that the spod board uses.
The general math is: totalactive = totaltime - idletime

[9:56.26 am]-> spod

 Rank:     Name:                 Time spent active:
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 1st       Spite                 44 minutes and 52 seconds.
 2nd       Newguy                34 minutes and 43 seconds.
 3rd       Apparent              0 seconds.
 4th       Achild                0 seconds.
 5th       Root                  39 minutes and 47 seconds ago.
 6th       Newgal                47 minutes and 3 seconds ago.
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 Spods listed:  6 (Page 1 of 1.)

[9:59.50 am]->
ou hear the town clock strike ten times, it's ten o'clock.
[Newguy has disconnected.]
[Newgal has disconnected.]
spod

 Rank:     Name:                 Time spent active:
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 1st       Spite                 44 minutes and 52 seconds.
 2nd       Newguy                34 minutes and 43 seconds.
 3rd       Apparent              0 seconds.
 4th       Achild                0 seconds.
 5th       Root                  39 minutes and 47 seconds ago.
 6th       Newgal                47 minutes and 3 seconds ago.
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 Spods listed:  6 (Page 1 of 1.)

[10:07.26 am]-> 