### PR TITLE
added support for .reconnect command(s)

### DIFF
--- a/doc/manual.txt
+++ b/doc/manual.txt
@@ -17208,7 +17208,7 @@ In most cases, things are given priority.
 -------------------------------------------------------------------------------
 
   .reconnect
-  ~~~~~~
+  ~~~~~~~~~~
   A '.reconnect' compound command attached to you executes when you reconnect 
   to the TCZ-based MUD (Useful for setting your preferences (Word-wrap, prompt, 
   etc.))

--- a/doc/manual.txt
+++ b/doc/manual.txt
@@ -25,7 +25,7 @@
 -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 
-                     Manual release date:  01/05/2020.
+                     Manual release date:  06/29/2020.
 
 
  TCZ (The Chatting Zone) is an advanced, user-friendly multi-user environment,
@@ -5432,9 +5432,9 @@ In most cases, things are given priority.
   compound command with the same name as the compound command currently
   being executed and execute it.
 
-  Setting the csuccess/cfailure branch of '.enter', '.leave', '.login' and
-  '.logout' compound commands to 'home' allows further '.enter', '.leave',
-  etc. compound commands up the area-tree to be executed.
+  Setting the csuccess/cfailure branch of '.enter', '.leave', '.login', 
+  '.reconnect', and '.logout' compound commands to 'home' allows further 
+  '.enter', '.leave', etc. compound commands up the area-tree to be executed.
 
 -------------------------------------------------------------------------------
 
@@ -17133,6 +17133,7 @@ In most cases, things are given priority.
   leave     .leave     RT   Container or area is exited.
             .leavecmd  C    Character leaves a room.
             .login     CRT  Character connects.
+            .reconnect CRT  Character reconnects.
   QUIT      .logout    CRT  Character disconnects.
   page      .page      C    'page' message is sent to character.
   profile   .profile   C    Profile of character is viewed.
@@ -17203,6 +17204,22 @@ In most cases, things are given priority.
   If the csuccess/cfailure branch of a '.login' compound command is set to
   'HOME', the TCZ-based MUD will continue searching up the area-tree for
   another '.login' compound command and execute it.
+
+-------------------------------------------------------------------------------
+
+  .reconnect
+  ~~~~~~
+  A '.reconnect' compound command attached to you executes when you reconnect 
+  to the TCZ-based MUD (Useful for setting your preferences (Word-wrap, prompt, 
+  etc.))
+
+  A '.reconnect' compound command in a room or container executes when a
+  character reconnects to the TCZ-based MUD and is in that room or any
+  of the rooms within it.
+
+  If the csuccess/cfailure branch of a '.reconnect' compound command is set to
+  'HOME', the TCZ-based MUD will continue searching up the area-tree for
+  another '.reconnect' compound command and execute it.
 
 -------------------------------------------------------------------------------
 

--- a/lib/generic.help.tcz
+++ b/lib/generic.help.tcz
@@ -17214,7 +17214,20 @@ A '%g%l.login%x' compound command in a room or container executes when a charact
 
 If the csuccess/cfailure branch of a '%g%l.login%x' compound command is set to '%y%lHOME%x', %@%m will continue searching up the area-tree for another '%g%l.login%x' compound command and execute it.
 <-SEPARATOR->
-Also, see '%g%l%<.logout%>%x', '%g%l%<.enter%>%x', '%g%l%<.leave%>%x' and '%g%l%<.action%>%x'
+Also, see '%g%l%<.reconnect%>%x', '%g%l%<.logout%>%x', '%g%l%<.enter%>%x', '%g%l%<.leave%>%x' and '%g%l%<.action%>%x'
+
+%COMMENT --------------------------------------------------------------------->
+
+%TOPIC .reconnect
+%TOPIC .reconnectcommand
+%TITLE Help on the '%w%l.reconnect%x' compound command
+A '%g%l.reconnect%x' compound command attached to you executes when you reconnect to %@%n (Useful for setting your preferences (Word-wrap, prompt, width, etc.))
+
+A '%g%l.reconnect%x' compound command in a room or container executes when a character reconnects to %@%n and is in that room or any of the rooms within it.
+
+If the csuccess/cfailure branch of a '%g%l.reconnect%x' compound command is set to '%y%lHOME%x', %@%m will continue searching up the area-tree for another '%g%l.reconnect%x' compound command and execute it.
+<-SEPARATOR->
+Also, see '%g%l%<.login%>%x', '%g%l%<.logout%>%x', '%g%l%<.enter%>%x', '%g%l%<.leave%>%x' and '%g%l%<.action%>%x'
 
 %COMMENT --------------------------------------------------------------------->
 
@@ -17227,7 +17240,7 @@ A '%g%l.logout%x' compound command in a room or container executes when a charac
 
 If the csuccess/cfailure branch of a '%g%l.logout%x' compound command is set to '%y%lHOME%x', %@%m will continue searching up the area-tree for another '%g%l.logout%x' compound command and execute it.
 <-SEPARATOR->
-Also, see '%g%l%<.login%>%x', '%g%l%<.enter%>%x', '%g%l%<.leave%>%x' and '%g%l%<.action%>%x'
+Also, see '%g%l%<.login%>%x', '%g%l%<.reconnect%>%x', '%g%l%<.enter%>%x', '%g%l%<.leave%>%x' and '%g%l%<.action%>%x'
 
 %COMMENT --------------------------------------------------------------------->
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -859,7 +859,7 @@ void tcz_connect_character(struct descriptor_data *d,dbref player,int create)
         db[d->player].owner              = cached_owner;
         db[d->player].data->player.chpid = cached_chpid;
      }
-    match_done();
+     match_done();
 
      /* ---->  Execute character's personal '.login' compound command  <---- */     
      command = match_simple(d->player,".login",COMMANDS,0,1);


### PR DESCRIPTION
Updated source, help files, and manual.

Example output with a global .reconnect (with a csucc) as well as a personal/local .reconnect on a user named Spite:

This is the global .reconnect
This is csucc.reconnect
This is spite's local .reconnect