### PR TITLE
Updates to finance system to use 5 min idle time properly

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -535,7 +535,6 @@
 #define DEFAULT_DEBIT                  20.0      /*  Default debit rate     */
 #define RAISE_MAXIMUM                  1000.0    /*  Maximum number of credits (Total) user may be given ('@credit')  */
 #define PAYMENT_GUARD                  10.0      /*  Default maximum payment which user can make from within a compound command  */
-#define IDLE_PAYMENT                   5         /*  Maximum idle time (In minutes) which counts towards next payment  */
 
 
 /* ---->  Profile constraints (Maximum lengths)  <---- */

--- a/src/finance.c
+++ b/src/finance.c
@@ -213,21 +213,18 @@ void finance_payment(struct descriptor_data *p)
      struct descriptor_data *d;
      time_t now;
 
-     /* ---->  Update counter, if idle time is less than IDLE_PAYMENT minutes  <---- */
+     /* ---->  Update counter, if idle time is less than IDLE_TIME minutes  <---- */
      if(!p || !Validchar(p->player)) return;
      gettime(now);
      diff = (now - p->last_time);
 
-     if((now - p->last_time) >= (IDLE_TIME * MINUTE))
-        db[p->player].data->player.idletime += (now - p->last_time);
-
      p->warning_level = 0;
      p->last_time     = now;
-     if(Puppet(p->player) || (diff > (IDLE_PAYMENT * MINUTE))) return;
+     if(Puppet(p->player) || (diff > (IDLE_TIME * MINUTE))) return;
 
-     /* ---->  If user has more than one connection below IDLE_PAYMENT idle time, don't update counter  <---- */
+     /* ---->  If user has more than one connection below IDLE_TIME time, don't update counter  <---- */
      for(d = descriptor_list; d; d = d->next)
-         if((d->player == p->player) && (d != p) && ((now - d->last_time) < (IDLE_PAYMENT * MINUTE)))
+         if((d->player == p->player) && (d != p) && ((now - d->last_time) < (IDLE_TIME * MINUTE)))
 	    return;
      db[p->player].data->player.payment += diff;
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -703,10 +703,10 @@ void tcz_command(struct descriptor_data *d,dbref player,const char *command)
      if(d->flags & CONNECTED)
         if(((now - d->last_time) >= (IDLE_TIME * MINUTE)) && Validchar(d->player))
            db[d->player].data->player.idletime += (now - d->last_time); 
-     d->last_time = now;
 
      /* ---->  Update hourly payment counter and zero idle time of user  <---- */
      finance_payment(d);
+     d->last_time = now;
 
      /* ---->  Trigger fuses attached to character and in their current location  <---- */
      db[player].lastused = now;


### PR DESCRIPTION
Users can now be paid credits for their active time (all multipliers preserved) and the finance system will not attempt to interfere with idle time tracking.  Also got rid of redundant representations of idle time/payment so that it uses one constant.  There was also a potential bug lurking in the use of a player's last_time in a context where descriptor's last_time was the right choice.  Would like to get this on the test port.