### PR TITLE
Fix for bug where idle time can be greater than connect time

### DIFF
--- a/include/modules_authors.h
+++ b/include/modules_authors.h
@@ -65,6 +65,8 @@ struct author_details authors[] = {
        {NULL, NULL, NULL, 0, 0,
 	  "NH",  "Nick Huggins",       NULL,        NULL},
        {NULL, NULL, NULL, 0, 0,
+	  "NA",  "Noah Anderson",      "Starace",   "noahmanderson@gmail.com"},
+       {NULL, NULL, NULL, 0, 0,
 	  "PC",  "Peter Crowther",     "Ozzard",    NULL},
        {NULL, NULL, NULL, 0, 0,
 	  "RH",  "Robin Heydon",       NULL,        NULL},

--- a/src/interface.c
+++ b/src/interface.c
@@ -825,11 +825,16 @@ void tcz_connect_character(struct descriptor_data *d,dbref player,int create)
      struct   descriptor_data *p;
      unsigned char number;
      short    cc;
+     time_t   now;
 
      if(((cc = server_count_connections(player,1)) == 1) || (db[player].data->player.lasttime == 0)) {
         update_lasttotal(player,1);
         d->start_time = db[player].data->player.lasttime;
      } else gettime(d->start_time);
+     gettime(now);
+     if (((now - d->last_time) >= (IDLE_TIME * MINUTE)) && Validchar(d->player))
+        db[d->player].data->player.idletime += (now - d->last_time);
+     d->last_time = now;
      server_sort_descriptor(d);
      if(cc == 1) db[player].flags2 &= ~(CHAT_OPERATOR|CHAT_PRIVATE);
      db[player].flags2 |=  CONNECTED;


### PR DESCRIPTION
A user's descriptor will now be updated for "activity" between entering their password and completing their connection to TCZ, eliminating cases where a player could be more idle than their connect time.  Also adding myself as an author to the in-MUD author command