### PR TITLE
Updated numerical array sorting to support negative numbers and also expanded to supporting floating point numbers

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -755,7 +755,8 @@ void array_traverse_elements(struct array_sort_data *current)
 /* ---->  Secondary sort key  <---- */
 unsigned char array_secondary_key(const char *ptr,const char **sortptr,int *ofs,int *len,unsigned char alpha,short offset,unsigned char elements,const char *separator)
 {
-	 unsigned short loop, pos = 0;
+	 unsigned short loop = 0;
+         unsigned short pos  = 0;
 
 	 if(!Blank(ptr)) {
 	    *sortptr = ptr, ptr = (elements) ? decompress(ptr):ptr;
@@ -784,11 +785,17 @@ unsigned char array_secondary_key(const char *ptr,const char **sortptr,int *ofs,
 	       *ofs = pos, *len = 0;
 	       return(1);
 	    } else {
+               if (atoi(ptr) != 0) {
+                   *ofs = pos;
+                   *len = 0;
+                   return(1);
+               }
 	       for(; *ptr && !isdigit(*ptr); ptr++, pos++);
 	       for(loop = 1; *ptr && (loop < offset); loop++) {
 		   for(; *ptr && isdigit(*ptr); ptr++, pos++);
 		   for(; *ptr && !isdigit(*ptr); ptr++, pos++);
 	       }
+               
 	       *ofs = pos, *len = 0;
 	       return(1);
 	    }
@@ -814,8 +821,8 @@ int array_secondary_match(const char *sortkey1,unsigned short sortofs1,unsigned 
     if(!alpha) {
        int num1,num2;
 
-       num1 = (isdigit(*scratch_buffer)) ? atol(scratch_buffer):0;
-       num2 = (isdigit(*scratch_return_string)) ? atol(scratch_return_string):0;
+       num1 = (isdigit(*scratch_buffer) || *scratch_buffer == '-') ? atol(scratch_buffer):0;
+       num2 = (isdigit(*scratch_return_string) || *scratch_return_string == '-') ? atol(scratch_return_string):0;
        return(num2 - num1);
     } else return(strcasecmp(scratch_return_string,scratch_buffer));
 }

--- a/src/array.c
+++ b/src/array.c
@@ -36,6 +36,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <math.h>
 
 #include "structures.h"
 #include "command.h"
@@ -785,7 +786,7 @@ unsigned char array_secondary_key(const char *ptr,const char **sortptr,int *ofs,
 	       *ofs = pos, *len = 0;
 	       return(1);
 	    } else {
-               if (atoi(ptr) != 0) {
+               if (atof(ptr) != 0.0) {
                    *ofs = pos;
                    *len = 0;
                    return(1);
@@ -819,11 +820,13 @@ int array_secondary_match(const char *sortkey1,unsigned short sortofs1,unsigned 
        strcpy(scratch_return_string,(!sortkey2) ? "":((elements) ? decompress(sortkey2):sortkey2) + sortofs2);
     }
     if(!alpha) {
-       int num1,num2;
+       double num1,num2,cmp;
 
-       num1 = (isdigit(*scratch_buffer) || *scratch_buffer == '-') ? atol(scratch_buffer):0;
-       num2 = (isdigit(*scratch_return_string) || *scratch_return_string == '-') ? atol(scratch_return_string):0;
-       return(num2 - num1);
+       num1 = (isdigit(*scratch_buffer) || *scratch_buffer == '-') ? atof(scratch_buffer):0;
+       num2 = (isdigit(*scratch_return_string) || *scratch_return_string == '-') ? atof(scratch_return_string):0;
+       cmp = num2 - num1;
+
+       return( (int) (cmp < 0.0) ? floor(cmp) : ceil(cmp));
     } else return(strcasecmp(scratch_return_string,scratch_buffer));
 }
 


### PR DESCRIPTION
Tested elements that are only numbers and also elements that have mixture of alphabetical and numerical elements.  Some examples of arrays sorted ascending and descending:

> @sort #43 = alpha descending elements 1 ";"
Elements of dynamic array Test.sort.array2[14](#43 D) sorted into descending alphabetical order.
[1:57.10 am]-> ex #43

Test.sort.array2[14](#43 D)
 Type:  Dynamic array;  Building Quota used:  15.
Owner:  Spite(#9 PWBPaybM).
Flags:  None.
 Size:  837 bytes (646 bytes compressed (22.8%))

[#14]  words;5.00;wordstuff
[#12]  words;5.01;wordstuff
[#1]  otherwords;-5;wordstuff
[#2]  otherwords;-4;wordstuff
[#3]  otherwords;-3;wordstuff
[#4]  otherwords;-2;wordstuff
[#5]  otherwords;-1;wordstuff
[#6]  otherwords;0;wordstuff
[#7]  otherwords;1;wordstuff
[#8]  otherwords;2;wordstuff
[#9]  otherwords;3;wordstuff
[#10]  otherwords;4;wordstuff
[#11]  otherwords;5;wordstuff
[#13]  morewords;0.1;some words

> @sort #43 = numerical ascending elements 2 ";"
Elements of dynamic array Test.sort.array2[15](#43 D) sorted into ascending numerical order.
[2:00.03 am]-> ex #43

Test.sort.array2[15](#43 D)
 Type:  Dynamic array;  Building Quota used:  16.
Owner:  Spite(#9 PWBPaybM).
Flags:  None.
 Size:  881 bytes (690 bytes compressed (21.7%))

[#1]  otherwords;-5;wordstuff
[#2]  otherwords;-4;wordstuff
[#3]  otherwords;-3;wordstuff
[#4]  otherwords;-2;wordstuff
[#15]  abc;-1.5;evenly
[#5]  otherwords;-1;wordstuff
[#6]  otherwords;0;wordstuff
[#13]  morewords;0.1;some words
[#7]  otherwords;1;wordstuff
[#8]  otherwords;2;wordstuff
[#9]  otherwords;3;wordstuff
[#10]  otherwords;4;wordstuff
[#14]  words;5.00;wordstuff
[#11]  otherwords;5;wordstuff
[#12]  words;5.01;wordstuff

> @sort #43 = numerical ascending elements 2 ";"
Elements of dynamic array Test.sort.array2[15](#43 D) sorted into ascending numerical order.
[2:00.03 am]-> ex #43

Test.sort.array2[15](#43 D)
 Type:  Dynamic array;  Building Quota used:  16.
Owner:  Spite(#9 PWBPaybM).
Flags:  None.
 Size:  881 bytes (690 bytes compressed (21.7%))

[#1]  otherwords;-5;wordstuff
[#2]  otherwords;-4;wordstuff
[#3]  otherwords;-3;wordstuff
[#4]  otherwords;-2;wordstuff
[#15]  abc;-1.5;evenly
[#5]  otherwords;-1;wordstuff
[#6]  otherwords;0;wordstuff
[#13]  morewords;0.1;some words
[#7]  otherwords;1;wordstuff
[#8]  otherwords;2;wordstuff
[#9]  otherwords;3;wordstuff
[#10]  otherwords;4;wordstuff
[#14]  words;5.00;wordstuff
[#11]  otherwords;5;wordstuff
[#12]  words;5.01;wordstuff

