### PR TITLE
Users can remain at the login screen for more than 5 minutes 

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1011,6 +1011,9 @@ void server_process_commands(void)
 
                      /* ---->  Process user command  <---- */
                      processed = server_command(d,command);
+
+                     /* ---->  Always keep descriptor current, idle penalties have been handled by now  <---- */
+                     d->last_time = now;
                      FREENULL(command);
 
                      if(reset_list) {


### PR DESCRIPTION
... so long as they remain active (issuing commands like who, set, tutorial, etc.)

Tested with various other idle time corner cases and still seems to work.