### PR TITLE
Fixed bug in multi-line @case structures

### DIFF
--- a/src/selection.c
+++ b/src/selection.c
@@ -162,13 +162,13 @@ char *selection_seek_end(char *str,int *lineno,unsigned char elsepart,unsigned c
                       if(((len = strlen(str + 1)) >= 4) && !strncasecmp(str + 1,"egin",4) && (!*(str + 5) || (*(str + 5) == ' ') || (*(str + 5) == '\n'))) {
                          type = FLOW_BEGIN >> 24;
                          onstack = 1;
-		      }
+                      }
                       break;
                  case 'c':
                  case 'C':
 
                       /* ---->  @case  <---- */
-                      if(!strncasecmp(str + 1,"ase ",4))
+                      if(!strncasecmp(str + 1,"ase ",4)) 
                          type = FLOW_CASE >> 24;
                       break;
                  case 'e':
@@ -358,6 +358,7 @@ void selection_case(CONTEXT)
 		       if(*ptr && ((*ptr == ',') || (*ptr == ':'))) {
                           if(*ptr == ':') command = 1;
                           *ptr++ = '\0';
+                          while (*value == '\n' && (value + 1)) value++;
                           filter_spaces((char *) value,(char *) value,0);
 
                           /* ---->  Single value or range of values?  <---- */


### PR DESCRIPTION
Tested with the following commands that had various issues on master:

CaseTest.orig(#39 C^~)
 Type:  Compound command;  Building Quota used:  10.
Owner:  Spite(#9 PWBPaybM).
Flags:  Censored, Tracing.
 Size:  397 bytes (309 bytes compressed (22.2%))
  Key:  *UNLOCKED*.

-----------------------------  Commands executed by compound command  -----------------------------
[001]  @case $3 do
[002]    a:@begin
[003]      @echo a
[004]    @end
[005]  
[006]    b:@begin
[007]      @echo b
[008]    @end
[009]  
[010]    c:@begin
[011]      @echo c
[012]    @end
[013]  
[014]    d:@begin
[015]      @echo d
[016]    @end
[017]  
[018]    e:@begin
[019]      @echo e
[020]    @end
[021]  
[022]    DEFAULT:@begin
[023]      @echo default
[024]    @end
[025]  
[026]  @end
---------------------------------------------------------------------------------------------------

Funny enough, if you delete line 25, you'd get different behavior (on master)

I used this command to verify a number of other forms of @case logic still worked:

Casetest(#55 C^)
 Type:  Compound command;  Building Quota used:  10.
Owner:  Spite(#9 PWBPaybM).
Flags:  Censored.
 Size:  354 bytes (289 bytes compressed (18.4%))
  Key:  *UNLOCKED*.

-----------------------------  Commands executed by compound command  -----------------------------
[001]  @chpid
[002]  @case $3 do
[003]     a: @echo a
[004]     ab: @echo ab
[005]     b: @echo b
[006]     c: @echo c
[007]     d: @echo d
[008]     e: @echo e
[009]     f: @echo f
[010]     1-9: @echo single digit
[011]     DEFAULT: @echo default
[012]  @end
---------------------------------------------------------------------------------------------------

