### PR TITLE
Fixed bug in @?strlen 

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -2446,7 +2446,10 @@ void query_strlen(CONTEXT)
      char   result[16];
 
      unparse_parameters(params,1,&arg,0);
-     sprintf(result,"%d",arg.len[0]);
+     if (arg.count == 0) 
+             sprintf(result,"%d",0);
+     else
+             sprintf(result,"%d",arg.len[0]);
      setreturn(result,COMMAND_SUCC);
 }
 


### PR DESCRIPTION
Fixed bug that returned uninitialized values when a 0-length or null argument was provided

cross-reference: TCZ-1