### PR TITLE
@Case

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -118,13 +118,13 @@ ELECTRICFENCE = 0
 # -Wall		All Warnings
 # -DLINUX 	We are using Linux
 #
-# You can mess around with these, they shouldn't stop sucessful compilation
+# You can mess around with these, they shouldn't stop successful compilation
 
 CFLAGS = -ggdb -Wall# -O
 
 # Other Important flags:
 #
-# Flags in ALL_CFLAGS are needed, and WILL affect/prevent sucessful compilation 
+# Flags in ALL_CFLAGS are needed, and WILL affect/prevent successful compilation 
 # and running - be careful with them
 #
 # -DANSI	We are (hopefully!) using ANSI C pass options which have

--- a/src/Makefile.rules
+++ b/src/Makefile.rules
@@ -188,7 +188,7 @@ endif
 
 define ROOT_WARN
 \\n\
-You may need to be root to sucessfully run make $@\\n\
+You may need to be root to successfully run make $@\\n\
 (e.g. if you don't own $(BINDIR) and $(SYSCONFDIR)).\\n\
 Type 'su' then root's password and run it again if necessary,\\n\
 but remember to return to your normal user id after a 'su' by\\n\

--- a/src/selection.c
+++ b/src/selection.c
@@ -314,7 +314,6 @@ void selection_case(CONTEXT)
      char   matchbuffer[BUFFER_LEN];
      dbref  cached_pid;
      char   endchar;
-     int    value_iter = 0;
 
      setreturn(ERROR,COMMAND_FAIL);
      cached_pid = Owner(player);
@@ -326,7 +325,6 @@ void selection_case(CONTEXT)
         if(strcasecmp(params,"do") && strncasecmp(params,"do ",3)) {
     	   for(casevalue = params; *params && !selection_do_keyword(params); params++);
 	} else casevalue = "";
-        fprintf(stderr,"\n%d: executing case_selection with casevalue = %s\n",__LINE__,casevalue);
 
         if(Blank(params)) {
 	   output(getdsc(player),player,0,1,0,ANSI_LGREEN"Sorry, '"ANSI_LYELLOW""ANSI_UNDERLINE"do"ANSI_LGREEN"' keyword omitted.");
@@ -351,8 +349,6 @@ void selection_case(CONTEXT)
            ptr = (char *) matchbuffer;
 
            while(*ptr && !matched) {
-                 value_iter++;
-                 fprintf(stderr,"%d: Starting iteration #%d\n",__LINE__,value_iter);
 
                  /* ---->  Case match values  <---- */
                  command = 0, wildcard = 0, which = 0, prefix = 0;
@@ -367,8 +363,6 @@ void selection_case(CONTEXT)
                                   offset++; 
                           }
                           filter_spaces((char *) value,(char *) value,0);
-
-                          fprintf(stderr,"%d:value found: %s\n",__LINE__,value);
 
                           /* ---->  Single value or range of values?  <---- */
                           if(!Blank(value)) {
@@ -402,9 +396,8 @@ void selection_case(CONTEXT)
 				      /* ---->  Default value  <---- */
 				      defaultvalue    = value;
                                       defaultline     = startline + offset + 1;
-                                      fprintf(stderr,"%d: defaultvalue = %s, defaultline = %d\n",__LINE__,defaultvalue,defaultline);
                                       which           = 0;
-				   } else if((!exactvalue || ((val1 == 2) && ((lrand48() % 100) < 50))) && !strcasecmp(value,casevalue)) {
+				   } else if((!exactvalue || ((val1 == 2) && ((lrand48() % 100) < 50))) && !strcasecmp(value,casevalue) && strcasecmp(casevalue,"default")) {
 
 				      /* ---->  Exact value  <---- */
 				      exactvalue    = value;
@@ -443,25 +436,18 @@ void selection_case(CONTEXT)
 
                     /* ---->  Get block command (Starting with '@begin')  <---- */
                     for(; *ptr && (*ptr != '\n'); ptr++);
-                    for(; *ptr && (*ptr == '\n'); offset++, ptr++) {
-                            fprintf(stderr,"%d: incrementing offset from %d to %d\n",__LINE__,offset, offset+1);
-
-                    } 
+                    for(; *ptr && (*ptr == '\n'); offset++, ptr++) 
                     for(; *ptr && (*ptr == ' ');  ptr++);
                     cendptr  = selection_seek_end((char *) (commands = ptr),&cendline,0,1);
                     ptr = (*cendptr) ? cendptr + 1:cendptr;
          	    *cendptr = '\0';
-                    fprintf(stderr,"%d: incrementing offset from %d to %d, cendline = %d\n",__LINE__,offset,offset+strcnt(commands,'\n'),cendline);
                     offset += strcnt(commands,'\n');
-                    fprintf(stderr,"%d: commands for value= %s...\n%s\n",__LINE__,value,commands);
 
                     /* ---->  Skip past '@end'  <---- */
                     for(; *ptr && (*ptr == ' '); ptr++);
                     if(!strncasecmp(ptr,"@end",4) && (!*ptr || (*(ptr + 4) == ' ') || (*(ptr + 4) == '\n'))) {
                        for(; *ptr && (*ptr != '\n'); ptr++);
-                       for(; *ptr && (*ptr == '\n'); offset++, ptr++) {
-                            fprintf(stderr,"%d: incrementing offset from %d to %d, ptr = '%c', ptr+1 = '%c'\n",__LINE__,offset, offset+1,*ptr,*(ptr+1));
-                       }
+                       for(; *ptr && (*ptr == '\n'); offset++, ptr++) 
                        for(; *ptr && (*ptr == ' '); ptr++);
 		    }
                     block = 1;
@@ -477,39 +463,28 @@ void selection_case(CONTEXT)
                     for(; *ptr && (*ptr == '\n'); offset++, ptr++);
                     block = 0;
 		 }
-                 if (block) fprintf(stderr,"%d: block detected (%s)..\n",__LINE__,value);
 
                  /* ---->  Set command(s) to execute  <---- */
                  if(!strcasecmp(value,"default")) {
-                         fprintf(stderr,"%d: We have a default value(%s) at the end of the loop\n",__LINE__,value);
                          if (!defaultcommands) {
                                  defaultcommands = commands;
                                  defaultblock    = block;
                          }
                  } else {
-                 switch(which) {
-                        case 1:
-			     exactcommands = commands;
-                             exactblock    = block;
-                             break;
-                        case 2:
-			     rangecommands = commands;
-                             rangeblock    = block;
-                             break;
-                        case 3:
-			     wildcommands = commands;
-                             wildblock    = block;
-                             break;
-                             /*
-                        default:
-                             if(!defaultcommands && strcasecmp("default",value)) {
-                             defaultcommands = commands;
-                             fprintf(stderr,"%d: defaultcommands set to %s\n",__LINE__,commands);
-                             defaultblock    = block;
-                             }
-                             break;
-                             */
-		 }
+                         switch(which) {
+                                 case 1:
+                                         exactcommands = commands;
+                                         exactblock    = block;
+                                         break;
+                                 case 2:
+                                         rangecommands = commands;
+                                         rangeblock    = block;
+                                         break;
+                                 case 3:
+                                         wildcommands = commands;
+                                         wildblock    = block;
+                                         break;
+                         }
                  }
                  value = NULL;
 	   }
@@ -563,7 +538,6 @@ void selection_case(CONTEXT)
 		 exactblock    = defaultblock;
 		 exactvalue    = defaultvalue;
 		 exactcommands = defaultcommands;
-                 fprintf(stderr,"%d: exactvalue = %s, exactline = %d\nexactcommands=%s\n",__LINE__,defaultvalue,defaultline,defaultcommands);
 	      }
 	   } else if(!exactvalue) {
 
@@ -575,7 +549,6 @@ void selection_case(CONTEXT)
                        exactblock    = defaultblock;
                        exactvalue    = defaultvalue;
                        exactcommands = defaultcommands;
-                       fprintf(stderr,"%d: exactvalue = %s, exactline = %d\nexactcommands=%s\n",__LINE__,defaultvalue,defaultline,defaultcommands);
 		    }
 		 } else {
                     exactline     = wildline;
@@ -593,7 +566,6 @@ void selection_case(CONTEXT)
 	   }
 
            /* ---->  Execute command  <---- */
-           fprintf(stderr,"%d: exactblock = %d, exactcommands = %s\n",__LINE__,exactblock,exactcommands);
            if(exactcommands) {
               current_line_number = exactline;
               strcpy(command_item,String(exactvalue));

--- a/src/selection.c
+++ b/src/selection.c
@@ -436,7 +436,7 @@ void selection_case(CONTEXT)
 
                     /* ---->  Get block command (Starting with '@begin')  <---- */
                     for(; *ptr && (*ptr != '\n'); ptr++);
-                    for(; *ptr && (*ptr == '\n'); offset++, ptr++) 
+                    for(; *ptr && (*ptr == '\n'); offset++, ptr++);
                     for(; *ptr && (*ptr == ' ');  ptr++);
                     cendptr  = selection_seek_end((char *) (commands = ptr),&cendline,0,1);
                     ptr = (*cendptr) ? cendptr + 1:cendptr;
@@ -447,7 +447,7 @@ void selection_case(CONTEXT)
                     for(; *ptr && (*ptr == ' '); ptr++);
                     if(!strncasecmp(ptr,"@end",4) && (!*ptr || (*(ptr + 4) == ' ') || (*(ptr + 4) == '\n'))) {
                        for(; *ptr && (*ptr != '\n'); ptr++);
-                       for(; *ptr && (*ptr == '\n'); offset++, ptr++) 
+                       for(; *ptr && (*ptr == '\n'); offset++, ptr++);
                        for(; *ptr && (*ptr == ' '); ptr++);
 		    }
                     block = 1;


### PR DESCRIPTION
I am feeling pretty good about these changes.  Tested thoroughly with the following two commands and tried multiple solutions:

Casetest(#66 C^)
 Type:  Compound command;  Building Quota used:  10.
Owner:  Spite(#9 PWBPaybM).
Flags:  Censored.
 Size:  746 bytes (477 bytes compressed (36.1%))
  Key:  *UNLOCKED*.

-----------------------------  Commands executed by compound command  -----------------------------
[001]   @case $3 do
[002]      single:@echo Single value.
[003]      one,two,three:@echo Value '%w%l$6%x'.
[004]      AA-ZZZ:@echo Exact range '%w%l$6%c-%w%l$7%x'.
[005]      B-P:@echo Exact range '%w%l$6%c-%w%l$7%x'.
[006]      0..9:@echo Exact range '%w%l$6%c..%w%l$7%x'.
[007]      Q->Z:@echo Prefix range '%w%l$6%c->%w%l$7%x'.
[008]      *and*:@echo Contains the wildcard '%w%l$6%x'.
[009]      a*:@echo Begins with the wildcard '%w%l$6%x'.
[010]      block:@begin
[011]               @echo %w%l>>>  %xThis demonstrates executing
[012]               @echo %w%l>>>  %xa block of commands.
[013]            @end
[014]      DEFAULT:@echo %r%lNothing matched.
[015]   @end
---------------------------------------------------------------------------------------------------

Casetest3.1(#54 C^)
 Type:  Compound command;  Building Quota used:  10.
Owner:  Spite(#9 PWBPaybM).
Flags:  Censored.
 Size:  413 bytes (319 bytes compressed (22.8%))
  Key:  *UNLOCKED*.

-----------------------------  Commands executed by compound command  -----------------------------
[001]  @case $3 do
[002]   a: @begin
[003]      @echo a
[004]    @end
[005]  
[006]   b: @begin
[007]      @temp line = b
[008]      @echo b
[009]    @end
[010]  
[011]   c: @begin
[012]      @echo c
[013]    @end
[014]   
[015]   d: @begin
[016]      @echo d
[017]    @end
[018]  
[019]    DEFAULT: @begin
[020]     @echo DEFAULT
[021]    @end
[022]  
[023]   DEFAULT: @echo 2nd default
[024]  
[025]  @end
---------------------------------------------------------------------------------------------------

[12:00.16 am]-> casetest3.1 a
a
[12:00.19 am]-> casetest3.1 b
b
[12:00.20 am]-> casetest3.1 c
c
[12:00.20 am]-> casetest3.1 d
d
[12:00.21 am]-> casetest3.1 
DEFAULT
[12:00.22 am]-> casetest3.1 default
DEFAULT


[12:03.25 am]-> casetest one
Value 'one'.
[12:04.33 am]-> casetest three
Value 'three'.
[12:04.36 am]-> casetest b
Exact range 'B-P'.
[12:04.39 am]-> casetest u
Prefix range 'Q->Z'.
[12:04.49 am]-> casetest block
>>> This demonstrates executing
>>> a block of commands.
[12:04.51 am]-> casetest default
Nothing matched.
[12:04.55 am]-> casetest 
Nothing matched.
[12:04.58 am]-> casetest 3
Exact range '0..9'.
[12:05.05 am]-> casetest cc
Exact range 'AA-ZZZ'.
[12:05.08 am]-> 