### PR TITLE
Moved filtering logic from query_filter to stringutils.c 

### DIFF
--- a/include/externs.h
+++ b/include/externs.h
@@ -1199,7 +1199,9 @@ extern  void            progress_meter          (unsigned long total,int divisor
 extern  const char      *gettextfield           (int number,char separator,const char *list,int skip,char *buffer);
 extern  const char      *settextfield           (const char *text,int number,char separator,const char *list,char *buffer);
 extern  int             strlen_ansi             (const char *str);
+extern  int             strlen_subs             (const char *str);
 extern  const char      *filter_ansi            (const char *str,char *buffer);
+extern  const char      *filter_substitutions   (const char *ptr,char *buffer);
 extern  void            init_strops             (struct str_ops *str_data,char *src,char *dest);
 extern  unsigned char   strins_limits           (struct str_ops *str_data,const char *str);
 extern  unsigned char   strcat_limits           (struct str_ops *str_data,const char *str);

--- a/src/preferences.c
+++ b/src/preferences.c
@@ -228,7 +228,7 @@ void prefs_prompt(dbref player,struct descriptor_data *d,const char *params)
 
      if(d->flags & CONNECTED) {
         if(!d->edit) {
-           if(strlen(params) <= 80) {
+           if(strlen_subs(params) <= 80) {
               if(!Blank(params)) {
                  FREENULL(d->user_prompt);
                  sprintf(scratch_return_string,ANSI_LWHITE"%s%s ",punctuate((char *) params,2,'\0'),ANSI_DWHITE);

--- a/src/query.c
+++ b/src/query.c
@@ -608,67 +608,13 @@ void query_filter(CONTEXT)
 {
      struct arg_data arg;
      const  char *ptr;
-     short  brackets;
      char   *tmp;
-
+       
      unparse_parameters(params,1,&arg,0);
      tmp = querybuf, ptr = arg.text[0];
-     while(*ptr)
-           switch(*ptr) {
-                  case '\x05':
 
-                       /* ---->  Hanging indent control  <---- */
-                       if(*(++ptr)) ptr++;
-                       break;
-                  case '\x06': 
-                  case '\x0E':
+     filter_substitutions(ptr,tmp);
 
-                       /* ---->  Skip rest of line/Toggle evaluation of HTML  <---- */
-                       ptr++;
-                       break;
-                  case '\x1B':
-
-                       /* ---->  'Hard' ANSI code  <---- */
-                       for(; *ptr && (*ptr != 'm'); ptr++);
-                       if(*ptr && (*ptr == 'm')) ptr++;
-                       break;
-                  case '%':
-                       if(*(++ptr)) {
-                          switch(*ptr) {
-                                 case '{':
-
-				      /* ---->  %{...} substition  <---- */
-                                      for(brackets = 0, ptr++; *ptr && !(!brackets && (*ptr == '}')); ptr++)
-                                          if(*ptr == '{') brackets++;
-                                             else if(*ptr == '}') brackets--;
-                                      if(*ptr && (*ptr == '}')) ptr++;
-                                      break;
-                                 case '#':
-
-				      /* ---->  %#NF#  <---- */
-				      if((*(ptr + 1) == 'n') || (*(ptr + 1) == 'N')) {
-					 if(!strncasecmp(ptr,"#NF#",4)) {
-					    ptr += 4;
-					 } else *tmp++ = '%';
-				      } else *tmp++ = '%';
-				      break;
-                                 case ' ':
-                                      *tmp++ = '%';
-				      break;
-                                 case '%':
-                                      *tmp++ = *ptr++;
-                                      break;
-                                 default:
-                                      ptr++;
-			  }
-		       } else *tmp++ = '%';
-                       break;
-                  default:
-                       if(isprint(*ptr)) {
-  	                  *tmp++ = *ptr++;
-		       } else ptr++;
-	   }
-     *tmp = '\0';
      setreturn(querybuf,COMMAND_SUCC);
 }
 

--- a/src/userlist.c
+++ b/src/userlist.c
@@ -1249,7 +1249,7 @@ void userlist_set_title(CONTEXT)
                  if(Blank(arg2) || !instring("%{",arg2)) {
                     if(Blank(arg2) || !instring("%h",arg2)) {
                        if(Blank(arg2) || Level2(db[player].owner) || (*arg2 != '.')) {
-                          if(strlen(arg2) <= 100) {
+                          if(strlen_subs(arg2) <= 100) {
 		   	     ansi_code_filter((char *) arg2,arg2,0);
                              setfield(character,TITLE,arg2,0);
                              if(!in_command) {


### PR DESCRIPTION
...and use it from both query_filter and fromstrlen_subs, which returns an integer length of a char* minus substitutions and ANSI codes. Updated the setting of prompt and title to check this filtered length instead of raw length.