### PR TITLE
Warnings

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -35,7 +35,7 @@ commands 'modules' and 'authors' within any TCZ-based MUD.
  Nick Huggins 	       1990-1991   Developer of UglyMUG code on which TCZ is
  (N/A)                             based.
 -------------------------------------------------------------------------------
- Noah Anderson         2020        Joined TCZ development.
+ Noah Anderson         2020-2021   Joined TCZ development.
  (Starace)
 -------------------------------------------------------------------------------
  Peter Crowther	       1990-1991   Developer of UglyMUG code on which TCZ is

--- a/src/bbs.c
+++ b/src/bbs.c
@@ -1185,23 +1185,23 @@ void bbs_latest(CONTEXT)
 
             /* ---->  Messages within sub-topics of topic  <---- */
             for(subtopic = topic->subtopics; subtopic; subtopic = subtopic->next)
-                if((!given || (!givensubtopic && (topic == given)) || (subtopic == givensubtopic)) && can_access_topic(player,subtopic,topic,0))
-                   for(message = subtopic->messages, mno = 1; message; message = message->next, mno++)
-                       if((owner == NOTHING) || ((message->owner == owner) && !(message->flags & MESSAGE_ANON))) {
-                          for(loop = 0; (loop < BBS_MAX_LATEST) && ranking[loop].message && (message->date < ranking[loop].message->date); loop++);
-                              if(loop < (BBS_MAX_LATEST - 1)) {
-                                 for(loop2 = (BBS_MAX_LATEST - 1); (loop2 > loop) && (loop2 > 0); loop2--) {
-                                     ranking[loop2].subtopic = ranking[loop2 - 1].subtopic;
-                                     ranking[loop2].message  = ranking[loop2 - 1].message;
-                                     ranking[loop2].number   = ranking[loop2 - 1].number;
-                                     ranking[loop2].topic    = ranking[loop2 - 1].topic;
-				 }
-                                 ranking[loop].subtopic = topic;
-                                 ranking[loop].message  = message;
-                                 ranking[loop].number   = mno;
-                                 ranking[loop].topic    = subtopic;
-			      }
-		       }
+               if((!given || (!givensubtopic && (topic == given)) || (subtopic == givensubtopic)) && can_access_topic(player,subtopic,topic,0))
+                  for(message = subtopic->messages, mno = 1; message; message = message->next, mno++)
+                     if((owner == NOTHING) || ((message->owner == owner) && !(message->flags & MESSAGE_ANON))) {
+                        for(loop = 0; (loop < BBS_MAX_LATEST) && ranking[loop].message && (message->date < ranking[loop].message->date); loop++);
+                        if(loop < (BBS_MAX_LATEST - 1)) {
+                            for(loop2 = (BBS_MAX_LATEST - 1); (loop2 > loop) && (loop2 > 0); loop2--) {
+                               ranking[loop2].subtopic = ranking[loop2 - 1].subtopic;
+                               ranking[loop2].message  = ranking[loop2 - 1].message;
+                               ranking[loop2].number   = ranking[loop2 - 1].number;
+                               ranking[loop2].topic    = ranking[loop2 - 1].topic;
+                            }
+                            ranking[loop].subtopic = topic;
+                            ranking[loop].message  = message;
+                            ranking[loop].number   = mno;
+                            ranking[loop].topic    = subtopic;
+                         }
+                     }
 	 }
 
      /* ---->  Display results  <---- */

--- a/src/friends.c
+++ b/src/friends.c
@@ -646,7 +646,7 @@ void friends_list(CONTEXT)
 
                     if((result = strlen(p2)) <= 21) {
                        for(ptr = p2 + result; result < 21; *ptr++ = ' ', result++);
-                           *ptr = '\0';
+                       *ptr = '\0';
 		    } else p2[21] = '\0';
                     strcat(scratch_buffer,"  ");
                     output(p, player, 2, 1, 23, "%s" ANSI_LWHITE "%s" ANSI_DCYAN ".\n", scratch_buffer, friendflags_description((val1) ? friend_flags(who, grp->cobject) : friend_flags(grp->cobject, who)));

--- a/src/userlist.c
+++ b/src/userlist.c
@@ -197,15 +197,15 @@ void userlist_who(struct descriptor_data *d)
            while(*ptr && (length < (twidth - 28)))
               if(*ptr == '\x1B') {
                  for(; *ptr && (*ptr != 'm'); ptr++);
-                    if(*ptr && (*ptr == 'm')) ptr++;
+                 if(*ptr && (*ptr == 'm')) ptr++;
               } else {
                  if(*ptr >= 32) length++;
                  ptr++;
               }
-              *ptr = '\0';
-              sprintf(scratch_buffer + strlen(scratch_buffer),"%s%s",scratch_return_string,colour);
-              for(ptr = (scratch_buffer + strlen(scratch_buffer)); length < (twidth - 28); *ptr++ = ' ', length++);
-              *ptr = '\0';
+           *ptr = '\0';
+           sprintf(scratch_buffer + strlen(scratch_buffer),"%s%s",scratch_return_string,colour);
+           for(ptr = (scratch_buffer + strlen(scratch_buffer)); length < (twidth - 28); *ptr++ = ' ', length++);
+           *ptr = '\0';
 
            /* ---->  Character's flags  <---- */
            if(!friendflags_set(d->player,grp->cunion->descriptor.player,NOTHING,FRIEND_EXCLUDE))


### PR DESCRIPTION
Solved for all instances of -Wmisleading-indentation on gcc 8.4

There are no changes to logic or semantics, this warning is focused on eliminating misleading whitespace.