### PR TITLE
Fix "unset date" in profile command and db serialization

### DIFF
--- a/include/db.h
+++ b/include/db.h
@@ -64,7 +64,8 @@
 #define CHANNEL_CONTEXT struct descriptor_data *d,char *chname,char *params,int option
 #define EDIT_CONTEXT    struct descriptor_data *d, int rfrom, int rto, int option, int numeric, int lines, unsigned char jump, char *text, char *params, int val1, char *editcmd, char *buffer
 #define PASS_CONTEXT    player,params,arg0,arg1,arg2,val1,val2
-#define UNSET_DATE      0xFFFFFFFF
+#define LEGACY_UNSET_DATE      0xFFFFFFFF
+#define UNSET_DATE      0xFFFFFFFFFFFFFFFF
 #define OPTCONTEXT      dbref player,const char *title,const char *value,int status,int *error,int *critical
 #define OPTSTATUS       NOTHING,NULL,NULL,1,NULL,NULL
 #define TCZ_INFINITY    0x7FFFFFFF

--- a/src/db.c
+++ b/src/db.c
@@ -3388,7 +3388,8 @@ static struct profile_data *db_read_profile(FILE *f,int version)
           if(version >= 61) profile->statusirl = db_read_int(f);
           if(version >= 70) profile->statusivl = db_read_int(f);
           if(version >= 64) {
-             profile->dob     = db_read_int(f);
+             profile->dob     = db_read_long(f);
+             if(profile->dob == LEGACY_UNSET_DATE) profile->dob = UNSET_DATE;
              profile->picture = (char *) db_read_string(f,1,1);
 	  }
        }


### PR DESCRIPTION
Solution for parsing long date instead of int date and allow for compatibility between old wrapping value and a new UNSET_DATE value.