### PR TITLE
Site lookup

### DIFF
--- a/src/sites.c
+++ b/src/sites.c
@@ -113,7 +113,7 @@ unsigned long text_to_ip(const char *ipaddress,unsigned long *mask)
 		  return(0);
 	       }
 	       if(*ipaddress) {
-		  if(((addr = atol(ipaddress)) < 0) || (addr > 255)) {
+		  if(((addr = atoi(ipaddress)) < 0) || (addr > 255)) {
 		     *mask = 0;
 		     return(0);
 		  }

--- a/src/sites.c
+++ b/src/sites.c
@@ -101,8 +101,8 @@ const char *siteflags_description(short flags)
 unsigned long text_to_ip(const char *ipaddress,unsigned long *mask)
 {
 	 unsigned long address = 0;
+	 unsigned int  addr;
 	 short         loop = 3;
-	 int           addr;
 
 	 *mask = 0;
 	 if(Blank(ipaddress)) return(0);


### PR DESCRIPTION
This caused some IP addresses to not be recognized when performing various @site functionality and also for the site description to be found and used with @?lastsite.

Sites DB was tested before and after to ensure that there is no change to the ascii representation in the file.  The bug only affected the sitelist lookup.