### PR TITLE
Recall all

### DIFF
--- a/doc/manual.txt
+++ b/doc/manual.txt
@@ -25,7 +25,7 @@
 -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 
-                     Manual release date:  10/2/2021.
+                     Manual release date:  3/9/2021.
 
 
  TCZ (The Chatting Zone) is an advanced, user-friendly multi-user environment,
@@ -5395,6 +5395,7 @@ In most cases, things are given priority.
   Recall
   ~~~~~~
   USAGE:  recall <NUMBER>
+          recall all
           recall list
           recall last
 
@@ -5402,7 +5403,8 @@ In most cases, things are given priority.
   via 'page' or 'tell'.
 
   Typing 'recall' on its own (Without any parameters) will recall the last
-  message sent to you (Along with the time, date and who it was from.)
+  message sent to you (Along with the time, date and who it was from.) Typing
+  'recall all' will show all of your recently received messages.
 
   'recall list' will list the names of the senders of the last 8 messages,
   along with the time and date.  You can see the actual message by typing

--- a/include/config.h
+++ b/include/config.h
@@ -629,7 +629,7 @@
 #define CHAT_INVITE_QUEUE_SIZE         10        /*  Size of invite queue for each chatting channel  */
 #define MATCH_RECURSION_LIMIT          100       /*  Maximum recursion limit for matching routines (match.c)  */
 #define WARN_LOGIN_INTERVAL            15        /*  Interval (Minutes) between giving warnings of failed logins  */
-#define MAX_STORED_MESSAGES            8         /*  Max. stored pages/tells per user  */
+#define MAX_STORED_MESSAGES            16        /*  Max. stored pages/tells per user  */
 #define DESTROY_QUEUE_SIZE             100       /*  Size of '@undestroy' object queue  */
 #define PROGRESS_UNITS                 4         /*  Number of units ('.') per megabyte on progress meter  */
 #define MAX_LIST_LIMIT                 100       /*  Maximum number of users who can be specified in a ','/';' separated list (Used by 'page', 'tell', friends/enemies code, etc.)  */
@@ -645,6 +645,7 @@
 #define SHORTDATEFMT                   "dd/mm/yyyy"        /*  Default short date format  */
 #define LONGDATEFMT                    "WW D MM yyyy"      /*  Default long date format  */
 #define TIMEFMT                        "h:nn.ss pp"        /*  Default time format  */
+#define SHORT24HTIMEFMT                "HH:nn"             /*  Default short time format  */
 #define DATEORDER                      0                   /*  Default date order (0 = Date first, 1 = Time first.)  */
 #define FULLDATEFMT                    LONGDATEFMT""DATESEPARATOR""TIMEFMT  /*  Default date & time format  */
 

--- a/include/externs.h
+++ b/include/externs.h
@@ -1200,6 +1200,7 @@ extern  time_t          string_to_date          (dbref player,const char *str,un
 extern  time_t          longdate_to_epoch       (unsigned long longdate);
 extern  unsigned long   epoch_to_longdate       (time_t epoch);
 extern  unsigned long   longdate_difference     (unsigned long longdate1,unsigned long longdate2);
+extern  void            trim_newlines           (char *str);
 
 
 /* ---->  From substitute.c  <---- */

--- a/include/modules_c.h
+++ b/include/modules_c.h
@@ -258,7 +258,7 @@
 
 /* ---->  From finance.c  <---- */
 #define module_finance_c_date "03/01/1997"
-#define module_finance_c_desc "Monetry system (Credits)"
+#define module_finance_c_desc "Monetary system (Credits)"
 #define module_finance_c_authors \
         "JPB | Y | 03/01/1997 | 02/12/2004 >>>"
 
@@ -391,7 +391,8 @@
 #define module_output_c_date "28/12/1994"
 #define module_output_c_desc "Output to users/descriptors"
 #define module_output_c_authors \
-        "JPB | Y | 28/12/1994 | 02/12/2004 >>>"
+        "JPB | Y | 28/12/1994 | 02/12/2004 >>>" \
+        "NA  | N | 10/07/2021 | 28/07/2021 >>>"
 
 
 /* ---->  From pager.c  <---- */
@@ -405,7 +406,8 @@
 #define module_pagetell_c_date "17/04/1995"
 #define module_pagetell_c_desc "'page'/'tell' commands"
 #define module_pagetell_c_authors \
-        "JPB | Y | 17/04/1995 | 02/12/2004 >>>"
+        "JPB | Y | 17/04/1995 | 02/12/2004 >>>" \
+        "NA  | N | 03/09/2021 | 04/09/2021 >>>"
 
 
 /* ---->  From predicates.c  <---- */
@@ -527,9 +529,10 @@
 
 /* ---->  From statistics.c  <---- */
 #define module_statistics_c_date "29/12/1994"
-#define module_statistics_c_desc "Database statistics"
+#define module_statistics_c_desc "Database and server statistics"
 #define module_statistics_c_authors \
-        "JPB | Y | 29/12/1994 | 02/12/2004 >>>"
+        "JPB | Y | 29/12/1994 | 02/12/2004 >>>" \
+        "NA  | N | 13/08/2021 | NULL >>>"
 
 
 /* ---->  From stringutils.c  <---- */

--- a/lib/generic.help.tcz
+++ b/lib/generic.help.tcz
@@ -15448,18 +15448,20 @@ Also, see '%g%l%uhelp tell%x', '%g%l%uhelp page%x', '%g%l%uhelp friends%x', '%g%
 %COMMENT --------------------------------------------------------------------->
 
 %TOPIC recall
+%TOPIC recallall
 %TOPIC recallingpages
 %TOPIC recallingtells
 %TITLE Help on '%w%lrecall%x'
 %c%lUSAGE:  %g%lrecall <NUMBER>
+        recall all
         recall list
         recall last%x
 
-The '%g%l%urecall%x' command allows you to recall the last 8 messages sent to you via '%g%l%upage%x' or '%g%l%utell%x'.
+The '%g%l%urecall%x' command allows you to recall the last 16 messages sent to you via '%g%l%upage%x' or '%g%l%utell%x'.
 
-Typing '%g%l%urecall%x' on its own (Without any parameters) will recall the last message sent to you (Along with the time, date and who it was from.)
+Typing '%g%l%urecall%x' on its own (Without any parameters) will recall the last message sent to you (Along with the time, date and who it was from.) Typing '%g%l%urecall all%x' will show all of your recently received message.
 
-'%g%lrecall list%x' will list the names of the senders of the last 8 messages, along with the time and date.  You can see the actual message by typing '%g%lrecall <NUMBER>%x', where %y%l<NUMBER>%x is the number of the message, e.g:  '%g%lrecall 1%x'.
+'%g%lrecall list%x' will list the names of the senders of the last 16 messages, along with the time and date.  You can see the actual message by typing '%g%lrecall <NUMBER>%x', where %y%l<NUMBER>%x is the number of the message, e.g:  '%g%lrecall 1%x'.
 
 You can reply to the last message you received by typing '%g%lreply <MESSAGE>%x' (See '%g%l%uhelp reply%x') or reply to the message %y%l<NUMBER>%x in the list by typing '%g%lpage <NUMBER> <MESSAGE>%x' or '%g%ltell <NUMBER> <MESSAGE>%x'.
 <-SEPARATOR->

--- a/src/pagetell.c
+++ b/src/pagetell.c
@@ -724,7 +724,7 @@ void pagetell_recall(CONTEXT)
                        if(p->messages[count].pager != player) output(p, player, 2, 1, 1, "\n %s from %s" ANSI_LWHITE "%s" ANSI_LCYAN " on " ANSI_LYELLOW "%s" ANSI_LCYAN ".\n", (p->messages[count].tell) ? "Tell" : "Page", Article(p->messages[count].pager, LOWER, INDEFINITE), getcname(NOTHING, p->messages[count].pager, 0, 0), date_to_string(now, UNSET_DATE, player, FULLDATEFMT));
                           else output(p, player, 2, 1, 1, "\n %s from yourself on " ANSI_LYELLOW "%s" ANSI_LCYAN ".\n", (p->messages[count].tell) ? "Tell" : "Page", date_to_string(now, UNSET_DATE, player, FULLDATEFMT));
                        output(p,player,0,1,0,separator(twidth,1,'-','='));
-		    } else if(!p->messages[count].tell) output(p,player,0,1,0,"");
+                    } else if(!p->messages[count].tell) output(p,player,0,1,0,"");
                     output(p, player, 2, 1, 3, " %s%s\n", Blank(p->messages[count].message) ? "Unknown" : decompress(p->messages[count].message), (p->messages[count].tell && !in_command) ? "\n" : "");
                     if(!in_command) {
                        output(p,player,0,1,0,separator(twidth,0,'-','-'));
@@ -732,10 +732,10 @@ void pagetell_recall(CONTEXT)
                           output(p, player, 2, 1, 1, ANSI_LWHITE " To reply to this message, simply type '" ANSI_LGREEN "page %d <MESSAGE>" ANSI_LWHITE "' or '" ANSI_LGREEN "tell %d <MESSAGE>" ANSI_LWHITE "'.\n", count + 1, count + 1);
                           else output(p, player, 2, 1, 1, ANSI_LWHITE " To reply to this message, simply type '" ANSI_LGREEN "reply <MESSAGE>" ANSI_LWHITE "'.\n");
                        output(p,player,0,1,0,separator(twidth,1,'-','='));
-		    }
+                    }
                     setreturn(OK,COMMAND_SUCC);
-		 } else output(p,player,0,1,0,ANSI_LGREEN"Sorry, you only have "ANSI_LWHITE"%d"ANSI_LGREEN" stored message%s.",p->messagecount,Plural(p->messagecount));
-	      } else output(p,player,0,1,0,ANSI_LGREEN"Sorry, that message number is invalid  -  Please specify a positive number.");
+                 } else output(p,player,0,1,0,ANSI_LGREEN"Sorry, you only have "ANSI_LWHITE"%d"ANSI_LGREEN" stored message%s.",p->messagecount,Plural(p->messagecount));
+              } else output(p,player,0,1,0,ANSI_LGREEN"Sorry, that message number is invalid  -  Please specify a positive number.");
            } else if (string_prefix("all",params)) {
 
               /* ---->  List all stored messages  <---- */
@@ -774,16 +774,16 @@ void pagetell_recall(CONTEXT)
                      else sprintf(scratch_buffer, ANSI_LGREEN " %-6s" ANSI_LWHITE "%s from yourself on ", scratch_return_string, (p->messages[count].tell) ? "Tell" : "Page");
                   now = p->messages[count].time + timediff;
                   output(p, player, 2, 1, 7, "%s" ANSI_LCYAN "%s" ANSI_LWHITE ".\n", scratch_buffer, date_to_string(now, UNSET_DATE, player, FULLDATEFMT));
-	      }
+              }
 
               if(!in_command) {
                  output(p,player,0,1,0,separator(twidth,0,'-','-'));
                  output(p, player, 2, 1, 1, ANSI_LWHITE " To recall one of the above messages, type '" ANSI_LGREEN "recall <NUMBER>" ANSI_LWHITE "'.  To recall all messages, type '" ANSI_LGREEN "recall all" ANSI_LWHITE "'.  To reply, simply type '" ANSI_LGREEN "page <NUMBER> <MESSAGE>" ANSI_LWHITE "' or '" ANSI_LGREEN "tell <NUMBER> <MESSAGE>" ANSI_LWHITE "'.\n");
                  output(p,player,0,1,0,separator(twidth,1,'-','='));
-	      }
+              }
               setreturn(OK,COMMAND_SUCC);
-	   }
-	} else output(p,player,0,1,0,ANSI_LGREEN"Sorry, no-one has sent any messages to you using '"ANSI_LWHITE"page"ANSI_LGREEN"' or '"ANSI_LWHITE"tell"ANSI_LGREEN"' yet.");
+           }
+        } else output(p,player,0,1,0,ANSI_LGREEN"Sorry, no-one has sent any messages to you using '"ANSI_LWHITE"page"ANSI_LGREEN"' or '"ANSI_LWHITE"tell"ANSI_LGREEN"' yet.");
      } else output(p,player,0,1,0,ANSI_LGREEN"Sorry, you must be connected to use the '"ANSI_LWHITE"recall"ANSI_LGREEN"' command.");
 }
 

--- a/src/stringutils.c
+++ b/src/stringutils.c
@@ -2291,3 +2291,19 @@ unsigned long longdate_difference(unsigned long longdate1,unsigned long longdate
 	    interval++, m_month1++;
 	 return(interval);
 }
+
+/* ---->  Remove one or more newline characters from the end of a string  <---- */
+void trim_newlines(char *str)
+{
+    int keep_iterating = 1;
+    int length;
+
+    if(str == NULL) return;
+    while(keep_iterating) {
+        length = strlen(str);
+        if(str[length-1] == '\n')
+            str[length-1] = '\0';
+        else
+            keep_iterating = 0;
+    }
+}


### PR DESCRIPTION
New subcommand for recall to allow users to read all recently sent messages. (More pager compatible)
Increased message retention from 8 to 16.
Updated help topics, TCZ manual,  and suggested commands when running 'recall list'