### PR TITLE
Fixed some mistakes in .pay and .paid help files

### DIFF
--- a/lib/generic.help.tcz
+++ b/lib/generic.help.tcz
@@ -15591,9 +15591,7 @@ Also, see '%g%l%uhelp tell%x', '%g%l%uhelp recall%x', '%g%l%uhelp .page%x' and '
 %TOPIC .paidcommand
 %TOPIC .paidcompoundcommand
 %TITLE Help on the '%w%l.paid%x' compound command
-If you have a compound command on you called '%y%l.paid%x', it will be executed when someone has
-successfully paid you credits.  Within the '%y%l.paid%x' compound command, %y%l$1%x holds the name of
-the person who paid you, and %y%l$2%x holds the amount of credits.
+If you have a compound command on you called '%y%l.paid%x', it will be executed when someone has successfully paid you credits.  Within the '%y%l.paid%x' compound command, %y%l$1%x holds the name of the person who paid you, and %y%l$2%x holds the amount of credits.
 
 %c%l%$Example:
 %~%c~~~~~~~~
@@ -15611,7 +15609,7 @@ If you have a compound command on you called '%y%l.pay%x', it will be executed w
 
 %c%l%$Example:
 %~%c~~~~~~~~
-%g%l@command .paid = |emote puts away %%p wallet after paying $2 credits to $1.
+%g%l@command .pay = |emote puts away %%p wallet after paying $2 credits to $1.
 <-SEPARATOR->
 Also, see '%g%l%uhelp @pay%x', '%g%l%uhelp @transfer%x', and '%g%l%uhelp .paid%x'.
 


### PR DESCRIPTION
After pulling these changes, use the following commands to reload online help without downtime:

@reload help .pay
@reload help .paid