### PR TITLE
TCZ-39 - Eliminating frequent memory leak as detected by valgrind.

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -711,6 +711,7 @@ void command_execute(dbref player,dbref command,const char *commands,unsigned ch
      if(command_return_value) {
         FREENULL(command_result);
         command_result = (char *) malloc_string(command_return_value);
+        FREENULL(command_return_value);
      } else command_return_value = cached_command_return_value;
 
      if(commands) {


### PR DESCRIPTION
I ran TCZ with valgrind for approximately 24 hours, trying a wide variety of things.  While some of the output said read sizes varied from initial allocated sizes, the only reports of definitely lost memory traced back to this memory allocated as a part of @returnvalue.  This memory appeared to be freed every time a new return value was set, and it also appeared to be freed any time a command was exited.  I found that if I freed the memory after it was deep copied as the return value of a command that all reports on valgrind disappeared. 

I'll leave this open for a little while in case anybody has better ideas on how to approach this.  Can confirm that after this change, there are no "definitely lost" bytes of memory with the exception of the one time allocation of the TCZ prompt, which is of little value freeing one time as TCZ is shutting down.