### PR TITLE
Accept https:// www addresses without appending http://

### DIFF
--- a/src/set.c
+++ b/src/set.c
@@ -2808,7 +2808,7 @@ void set_www(CONTEXT)
            if(!Readonly(character)) {
 	      if(strlen(arg2) <= 128) {
                  if(Level2(db[player].owner) || !strchr(arg2,'\n')) {
-                    if(!Level2(player) && !Blank(arg2) && strncasecmp(arg2,"http://",7))
+                    if(!Level2(player) && !Blank(arg2) && strncasecmp(arg2,"http://",7) && strncasecmp(arg2,"https://",8))
                        sprintf(scratch_return_string,"http://%s",arg2);
                           else strcpy(scratch_return_string,arg2);
 


### PR DESCRIPTION
Current  behavior: 
TCZ> @www me = google.com
Your web site address is now 'http://google.com'.
TCZ> @www me = https://google.com
Your web site address is now 'http://https://google.com'.

Fixed / Expected behavior: 
TCZ> @www me = google.com
Your web site address is now 'http://google.com'.
TCZ> @www me = https://google.com
Your web site address is now 'https://google.com'.