### PR TITLE
Modify logic for forcing float vs. int in calc logic

### DIFF
--- a/src/calculate.c
+++ b/src/calculate.c
@@ -513,9 +513,12 @@ void calculate_evaluate(CONTEXT)
 		   }
 
                    if(numeric) {
+                      int force_float = (floating || 
+                         (bool_op == CALC_CONVFLOAT) || 
+                         CALC_SCIENTIFIC(bool_op)) && bool_op != CALC_CONVINT;
 
                       /* ---->  Numeric op.  <---- */
-                      if(floating && ((bool_op != CALC_CONVINT) || (bool_op == CALC_CONVFLOAT) || CALC_SCIENTIFIC(bool_op))) {
+                      if(force_float) { 
                          temp.calcfloat = tofloat(calcbuf,&dps);
                          if((dps != NOTHING) && ((dp == NOTHING) || (dps > dp))) dp = dps;
                          if(negate) temp.calcfloat = 0 - temp.calcfloat;


### PR DESCRIPTION
Modified when we force float vs. int in calc worlflow. 

Left is previous output, Right is current / expected output. Test done in game on local server.

<img width="1485" height="809" alt="image" src="https://github.com/user-attachments/assets/60a55057-f8fd-48f6-8f74-d4711b5165c5" />

 @echo Addition - 2+2 - {@eval 2 + 2}  ...gives '4'
@echo Substraction - 123456789 - 6789 - {@eval 123456789 - 6789}  ...gives '123450000'
@echo Division - 9999 / 99 - {@eval 9999 / 99}  ...gives '101'
@echo Multiplication - 758 * 123 - {@eval 758 * 123}  ...gives '93234'
@echo Modulus - 6 % 4 - {@eval 6 % 4}  ...gives '2'
@echo Exponent - {@eval 2 ^ 8} ...gives '256'
@echo Sqrt - {@eval sqrt 4} ...gives '2.0'
@echo Sine - {@eval sin 2.3}   ...gives '0.7457052122'
@echo Cosine - {@eval cos 2.3}   ...gives '-0.6662760213'
@echo Tangent - {@eval tan 2.3}   ...gives '-1.1192136417'
@echo Arc Sine - {@eval asin 0.5}      ...gives '0.5235987756'
@echo Arc Cosine - {@eval acos 0.5}      ...gives '1.0471975512'
@echo Arc Tangent - {@eval atan 0.5}      ...gives '0.463647609'
@echo Absolute Value - {@eval 1 + (abs -3)}  ...gives '4'
@echo Cast to int - {@eval int 3.45}      ...gives '3'
@echo Cast to float - {@eval float 2}       ...gives '2.0'
@echo Logical AND {@eval 1 && 1}   ...gives '1'
@echo Logical AND {@eval 1 and 0}  ...gives '0'
@echo Logical OR {@eval 1 || 0}   ...gives '1'
@echo Logical OR {@eval 0 or 0}   ...gives '0'
@echo Logical NOT {@eval !1}       ...gives '0'
@echo Logical NOT {@eval not 0}    ...gives '1'
@echo Bitwise AND {@eval 255 & 15}  ...gives '15'.
@echo Bitwise OR {@eval 16 | 32}   ...gives '48'.
@echo Bitwise NOT {@eval ~1}        ...gives '-2'.
@echo Bitwise shift-left {@eval 2 << 1}    ...gives '4'.
@echo Bitwise shift-right {@eval 2 >> 1}    ...gives '1'.
@echo Equal {@eval "hello" = "hello"}   ...gives '1' (TRUE.)
@echo Not Equal {@eval "hello" <> "hello"}  ...gives '0' (FALSE.)
@echo Less Than {@eval 10 < 50}             ...gives '1'.
@echo Greater Than {@eval 5 > 1}               ...gives '1'.
@echo <= {@eval 3 <= 10}             ...gives '1'.
@echo >= {@eval 10 >= 10}            ...gives '1'.